### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,8 +982,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ### 🌟 Stargazers Community
 
-[![Stargazers repo roster for @muhittincamdali/iOS-Performance-Optimization-Toolkit](https://starchart.cc/muhittincamdali/iOS-Performance-Optimization-Toolkit.svg)](https://github.com/muhittincamdali/iOS-Performance-Optimization-Toolkit/stargazers)
-
 **⭐ Star this repository if it helped you!**
 
 **💫 Join our amazing community of developers!**


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.