### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,30 @@
+# Documentation Index
+
+- [](&)Documentation/Analytics/Analytics.md
+- [](&)Documentation/AnalyticsAPI.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Battery/BatteryOptimization.md
+- [](&)Documentation/BatteryOptimizationAPI.md
+- [](&)Documentation/BatteryOptimizationGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/CPU/CPUOptimization.md
+- [](&)Documentation/CPUOptimizationAPI.md
+- [](&)Documentation/CPUOptimizationGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/GettingStarted/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/Memory/MemoryOptimization.md
+- [](&)Documentation/MemoryOptimizationAPI.md
+- [](&)Documentation/MemoryOptimizationGuide.md
+- [](&)Documentation/Performance/Performance.md
+- [](&)Documentation/PerformanceMonitorAPI.md
+- [](&)Documentation/ProfilingAPI.md
+- [](&)Documentation/ProfilingGuide.md
+- [](&)Documentation/TestingAPI.md
+- [](&)Documentation/TestingGuide.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/UI/UIOptimization.md
+- [](&)Documentation/UIPerformanceAPI.md
+- [](&)Documentation/UIPerformanceGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,9 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedPerformanceExamples.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicMemoryExample.swift
+- ``Examples/BasicExamples/PerformanceExamples.swift
+- ``Examples/BatteryExamples/BasicBatteryExample.swift
+- ``Examples/CPUExamples/BasicCPUExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.